### PR TITLE
Allow LoopVectorization 0.7 and 0.8.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,6 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 Arpack = "0.4"
-LoopVectorization = "0.6"
+LoopVectorization = "0.6,0.7,0.8"
 StatsBase = "0.32"
 julia = "1.4"


### PR DESCRIPTION
This will solve:
https://discourse.julialang.org/t/trying-to-speed-up-laplace-equation-solver/43862/14?u=elrod

If it is possible for the arrays to be empty, then supporting LoopVectorization 0.8 will require adding `check_empty=true` as an argument to `@avx`.

Tests passed locally.