### PR TITLE
[docs, minor] Fix function name in documentation

### DIFF
--- a/src/MeshModificationModule.jl
+++ b/src/MeshModificationModule.jl
@@ -518,7 +518,7 @@ Let us say there are nodes not connected to any finite element that you would
 like to remove from the mesh: here is how that would be accomplished.
 ```
 connected = findunconnnodes(fens, fes);
-fens, new_numbering = compactfens(fens, connected);
+fens, new_numbering = compactnodes(fens, connected);
 fes = renumberconn!(fes, new_numbering);
 ```
 Finally, check that the mesh is valid:


### PR DESCRIPTION
Small typo. Perhaps the function used to be named `compactfens`. Also, it seems that `validate_mesh` is not defined. I'm not sure if it has been renamed, or if it's just a placeholder for a user-defined function.

Oliver