### PR TITLE
Inflate box during partitioning in nodal transferfield!

### DIFF
--- a/src/FEMMBaseModule.jl
+++ b/src/FEMMBaseModule.jl
@@ -266,8 +266,9 @@ function transferfield!(ff::F, fensf::FENodeSet, fesf::AbstractFESet, fc::F, fen
         # Find the bounding box
         subbox = boundingbox(fensf.xyz[pnl, :])
         tol = 2*geometricaltolerance # increase the box a bit
+        subbox = inflatebox!(subbox, tol)
         # Construct a sub mesh of the coarse mesh that covers the nodes from this partition
-        sublist = selectelem(fensc, fesc, overlappingbox = subbox, inflate = tol)
+        sublist = selectelem(fensc, fesc, overlappingbox = subbox)
         if !isempty(sublist) # there are some finite elements to work with
             fescsub = subset(fesc, sublist)
             connected = findunconnnodes(fensc, fescsub);


### PR DESCRIPTION
Hi Petr,

I was using `transferfield!` for a nodal field and trying to use the `geometricaltolerance` option to allow nodes on the fine mesh to be slightly outside of the coarse mesh, but it didn't seem to be working as I expected.

# `transferfield!`

I noticed that the box is being inflated here when searching for elements in the coarse mesh element subset near the given node

https://github.com/PetrKryslUCSD/FinEtools.jl/blob/44aa6f0a1f4f8eb2143ba75b17c9ed6810efb655/src/FEMMBaseModule.jl#L290-L292

However, I was finding that the coarse mesh element subset itself was empty, so inflating the box around the node didn't help.
Looking earlier in the code to when the coarse mesh subset is being constructed for each partition of the fine mesh, something similar is done, but in a slightly different way:

https://github.com/PetrKryslUCSD/FinEtools.jl/blob/44aa6f0a1f4f8eb2143ba75b17c9ed6810efb655/src/FEMMBaseModule.jl#L268-L270

Rather than explicitly calling `inflatebox!`, the `inflate` keyword argument is passed to `selectelem`. 

# `selectelem`

However, the `inflate` kwarg is not used by `selectelem`. You can see here that it's not explicitly parsed

https://github.com/PetrKryslUCSD/FinEtools.jl/blob/44aa6f0a1f4f8eb2143ba75b17c9ed6810efb655/src/MeshSelectionModule.jl#L192-L211

and it's not used in the `overlappingbox` section of the function

https://github.com/PetrKryslUCSD/FinEtools.jl/blob/44aa6f0a1f4f8eb2143ba75b17c9ed6810efb655/src/MeshSelectionModule.jl#L389-L402

There is some code here that inflates the box explicitly, but it's commented out and seems out-of-date:

https://github.com/PetrKryslUCSD/FinEtools.jl/blob/44aa6f0a1f4f8eb2143ba75b17c9ed6810efb655/src/MeshSelectionModule.jl#L250-L262

The `inflate` kwarg _does_ get implicitly passed to `selectnode` and onto `vselect` which does use it explicitly here

https://github.com/PetrKryslUCSD/FinEtools.jl/blob/44aa6f0a1f4f8eb2143ba75b17c9ed6810efb655/src/MeshSelectionModule.jl#L567

but this only happens after the overlapping elements are already selected, and only impacts the selection of nodes _given_ the overlapping elements that have already been found.

# Solution options

1. The quick fix for `transferfield!` would be to explicitly use the `inflatebox!` and forget about the `inflate = tol` option, as I've done in this PR.
2. Perhaps the better solution is to actually use the `inflate` kwarg in the `overlappingbox` section of `selectelem`. I'm not sure if the current behavior is intended, though, or if it's just a bug. And I'm not sure whether other functions (intentionally or otherwise) are relying on the current behavior. But if the current behavior is not intended, then let's close this PR and fix the core issue.

What do you think?

Oliver