### PR TITLE
update ChunkSplitters compat entry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]
-ChunkSplitters = "^0.1"
+ChunkSplitters = "^0.1, 1"
 DataDrop = "^0.1"
 DelimitedFiles = "^1.7"
 HDF5 = "^0.15"


### PR DESCRIPTION
The 1.0.0 version of ChunkSplitters is non-breaking. It is only to define the stable API.