### PR TITLE
Update compat entry for ChunkSplitters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]
-ChunkSplitters = "^0.1, 1"
+ChunkSplitters = "^0.1, 1, 2"
 DataDrop = "^0.1"
 DelimitedFiles = "^1.7"
 HDF5 = "^0.16"


### PR DESCRIPTION
We released a formally breaking version of ChunkSplitters (v2.0.0), but which does not affect most users. It won´t affect your package, so here I'm proposing the update of the compat entry to accept the 2.0 version.